### PR TITLE
allow use in Python 3.7

### DIFF
--- a/circuitpython_typing/__init__.py
+++ b/circuitpython_typing/__init__.py
@@ -14,7 +14,15 @@ Types needed for type annotation that are not in `typing`
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_Typing.git"
 
-from typing import Union, Protocol, Optional
+
+from typing import Union, Optional
+
+# Protocol was introduced in Python 3.8.
+try:
+    from typing import Protocol
+except ImportError:
+    from typing_extensions import Protocol
+
 from array import array
 
 ReadableBuffer = Union[bytes, bytearray, memoryview, array]
@@ -42,7 +50,8 @@ class ByteStream(Protocol):
     * `usb_cdc.Serial`
     """
 
-    def read(self, count: Optional[int] = None, /) -> Optional[bytes]:
+    # Should be `, /)`, but not available in Python 3.7.
+    def read(self, count: Optional[int] = None) -> Optional[bytes]:
         """Read ``count`` bytes from the stream.
         If ``count`` bytes are not immediately available,
         or if the parameter is not specified in the call,
@@ -50,6 +59,7 @@ class ByteStream(Protocol):
         """
         ...
 
-    def write(self, buf: ReadableBuffer, /) -> Optional[int]:
+    # Should be `, /)`, but not available in Python 3.7.
+    def write(self, buf: ReadableBuffer) -> Optional[int]:
         """Write the bytes in ``buf`` to the stream."""
         ...

--- a/circuitpython_typing/socket.py
+++ b/circuitpython_typing/socket.py
@@ -11,7 +11,14 @@ Type annotation definitions for sockets. Used for `adafruit_requests` and simila
 
 from ssl import SSLContext
 from types import ModuleType
-from typing import Any, Optional, Protocol, Tuple, Union
+from typing import Any, Optional, Tuple, Union
+
+# Protocol was introduced in Python 3.8.
+try:
+    from typing import Protocol
+except ImportError:
+    from typing_extensions import Protocol
+
 
 # Based on https://github.com/python/typeshed/blob/master/stdlib/_socket.pyi
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2022 Dan Halbert for Adafruit Industries
 #
 # SPDX-License-Identifier: MIT
+
+typing_extensions; python_version <= '3.7'

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     # Author details
     author="Adafruit Industries",
     author_email="circuitpython@adafruit.com",
-    install_requires=[],
+    install_requires=["typing_extensions; python_version <= '3.7'"],
     # Choose your license
     license="MIT",
     # See https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
Fixes #3.

- Use `typing_extensions` for `Protocol` for Python <= 3.7.
- Don't use `/` to indicate position-only arguments.

Tested on Python 3.7.11.