### PR TITLE
Add str to ReadableBuffer types

### DIFF
--- a/circuitpython_typing/__init__.py
+++ b/circuitpython_typing/__init__.py
@@ -27,6 +27,7 @@ from array import array
 
 ReadableBuffer = Union[bytes, bytearray, memoryview, array]
 """Classes that implement the readable buffer protocol
+  * `str`
   * `bytes`
   * `bytearray`
   * `memoryview`


### PR DESCRIPTION
`str` implements buffer. I came across this when my IDE complained about passing strings to `wifi.radio.connect`.
Some other types can be found by searching for `.buffer_p =` in the codebase but I'm not sure if/how they should be added.