### PR TITLE
Add I2CDeviceDriver duck type

### DIFF
--- a/circuitpython_typing/device_drivers.py
+++ b/circuitpython_typing/device_drivers.py
@@ -18,6 +18,7 @@ except ImportError:
     from typing_extensions import Protocol
 
 
+# pylint: disable=too-few-public-methods
 class I2CDeviceDriver(Protocol):
     """Describes classes that are drivers utilizing `I2CDevice`"""
 

--- a/circuitpython_typing/device_drivers.py
+++ b/circuitpython_typing/device_drivers.py
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022 Alec Delaney
+# SPDX-License-Identifier: MIT
+"""
+`circuitpython_typing.device_drivers`
+================================================================================
+
+Type annotation definitions for device drivers. Used for `adafruit_register`.
+
+* Author(s): Alec Delaney
+"""
+
+from adafruit_bus_device import I2CDevice
+
+# # Protocol was introduced in Python 3.8.
+try:
+    from typing import Protocol
+except ImportError:
+    from typing_extensions import Protocol
+
+class I2CDeviceDriver(Protocol):
+    """Describes classes that are drivers utilizing `I2CDevice`"""
+
+    i2c_device: I2CDevice

--- a/circuitpython_typing/device_drivers.py
+++ b/circuitpython_typing/device_drivers.py
@@ -17,6 +17,7 @@ try:
 except ImportError:
     from typing_extensions import Protocol
 
+
 class I2CDeviceDriver(Protocol):
     """Describes classes that are drivers utilizing `I2CDevice`"""
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@
 # SPDX-License-Identifier: MIT
 
 typing_extensions; python_version <= '3.7'
+adafruit-circuitpython-busdevice

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,10 @@ setup(
     # Author details
     author="Adafruit Industries",
     author_email="circuitpython@adafruit.com",
-    install_requires=["typing_extensions; python_version <= '3.7'"],
+    install_requires=[
+        "typing_extensions; python_version <= '3.7'",
+        "adafruit-circuitpython-busdevice",
+    ],
     # Choose your license
     license="MIT",
     # See https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
Per conversation in https://github.com/adafruit/Adafruit_CircuitPython_SI7021/pull/30:

This PR sets up the ability to use duck typing as part of `adafruit_register` method type annotations.  I wanted to do the same for `SPIDevice` but I think devices using it vary in the attribute name that stores it.  It may be worth refactoring those classes to use the same name so the same solution here can be used.