### PR TITLE
Fix I2CDevice import

### DIFF
--- a/circuitpython_typing/device_drivers.py
+++ b/circuitpython_typing/device_drivers.py
@@ -9,7 +9,7 @@ Type annotation definitions for device drivers. Used for `adafruit_register`.
 * Author(s): Alec Delaney
 """
 
-from adafruit_bus_device import I2CDevice
+from adafruit_bus_device.i2c_device import I2CDevice
 
 # # Protocol was introduced in Python 3.8.
 try:


### PR DESCRIPTION
Didn't import properly, but I don't think this was used yet, so should be fine.  When I get to type annotating `adafruit_register`, I can force it to use a typing of some version or above, as well.