### PR TITLE
Add type annotation protocols for LEDs

### DIFF
--- a/circuitpython_typing/led.py
+++ b/circuitpython_typing/led.py
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022 Alec Delaney
+#
+# SPDX-License-Identifier: MIT
+
+"""
+`circuitpython_typing.led`
+================================================================================
+
+Type annotation definitions for device drivers. Used for where LEDs are
+type annotated.
+
+* Author(s): Alec Delaney
+"""
+
+# # Protocol was introduced in Python 3.8.
+try:
+    from typing import Union, Tuple, Protocol
+except ImportError:
+    from typing_extensions import Protocol
+
+ColorBasedColorUnion = Union[int, Tuple[int, int, int]]
+FillBasedColorUnion = Union[ColorBasedColorUnion, Tuple[int, int, int, int]]
+
+class ColorBasedLED(Protocol):
+
+    def color(self, value: ColorBasedColorUnion) -> None:
+        ...
+
+class FillBasedLED(Protocol):
+
+    def fill(self, color: FillBasedColorUnion) -> None:
+        ...

--- a/circuitpython_typing/led.py
+++ b/circuitpython_typing/led.py
@@ -21,12 +21,18 @@ except ImportError:
 ColorBasedColorUnion = Union[int, Tuple[int, int, int]]
 FillBasedColorUnion = Union[ColorBasedColorUnion, Tuple[int, int, int, int]]
 
+
 class ColorBasedLED(Protocol):
+    """Protocol for LEDs using the :meth:`color` method"""
 
     def color(self, value: ColorBasedColorUnion) -> None:
+        """Sets the color of the LED"""
         ...
 
+
 class FillBasedLED(Protocol):
+    """Protocol for LEDs using the :meth:`fill` method"""
 
     def fill(self, color: FillBasedColorUnion) -> None:
+        """Sets the color of the LED"""
         ...


### PR DESCRIPTION
Useful for typing LEDs without having to import them.  Spawned from typing `adafruit_esp32spi`.