### PR TITLE
Add PWMOut protocol

### DIFF
--- a/circuitpython_typing/led.py
+++ b/circuitpython_typing/led.py
@@ -6,8 +6,7 @@
 `circuitpython_typing.led`
 ================================================================================
 
-Type annotation definitions for device drivers. Used for where LEDs are
-type annotated.
+Type annotation definitions for LEDs.
 
 * Author(s): Alec Delaney
 """

--- a/circuitpython_typing/pwmio.py
+++ b/circuitpython_typing/pwmio.py
@@ -13,9 +13,10 @@ Type annotation definitions for PWMOut where Blinka doesn't otherwise define it.
 
 # # Protocol was introduced in Python 3.8.
 try:
-    from typing import Union, Tuple, Protocol
+    from typing import Protocol
 except ImportError:
     from typing_extensions import Protocol
+
 
 class PWMOut(Protocol):
     """Protocol that implements, at the bare minimum, the `duty_cycle` property"""

--- a/circuitpython_typing/pwmio.py
+++ b/circuitpython_typing/pwmio.py
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022 Alec Delaney
+#
+# SPDX-License-Identifier: MIT
+
+"""
+`circuitpython_typing.pwmio`
+================================================================================
+
+Type annotation definitions for PWMOut where Blinka doesn't otherwise define it.
+
+* Author(s): Alec Delaney
+"""
+
+# # Protocol was introduced in Python 3.8.
+try:
+    from typing import Union, Tuple, Protocol
+except ImportError:
+    from typing_extensions import Protocol
+
+class PWMOut(Protocol):
+    """Protocol that implements, at the bare minimum, the `duty_cycle` property"""
+
+    @property
+    def duty_cycle(self) -> int:
+        """The duty cycle as a ratio using 16-bits"""
+        ...
+
+    @duty_cycle.setter
+    def duty_cycle(self, duty_cycle: int) -> None:
+        ...


### PR DESCRIPTION
A `PWMOut` protocol is needed for when Blinka doesn't define it, but a library uses it for type annotations.  This is at least needed for `adafruit_motor` since it can be used via `adafruit_motorkit` on Blinka, but currently fails because some platforms don't implement `PWMOut` (see https://github.com/adafruit/Adafruit_CircuitPython_MotorKit/issues/45).

I'm adding it here as opposed to the library because I'm not sure if this will come up again.  If it makes more sense to define in the library itself up in the typing block, I'm happy to move things there!

Merging this (or moving into `adafruit_motor` will allow a for a fix to be written for the aforementioned issue.