### PR TITLE
Add PIL.Image protocol

### DIFF
--- a/circuitpython_typing/pil.py
+++ b/circuitpython_typing/pil.py
@@ -19,13 +19,18 @@ try:
 except ImportError:
     from typing_extensions import Protocol
 
-class PixelAccess(Protocol):
 
+class PixelAccess(Protocol):
+    """Type annotation for PIL's PixelAccess class"""
+
+    # pylint: disable=invalid-name
     def __getitem__(self, xy: Tuple[int, int]) -> int:
         """Get pixels by x, y coordinate"""
         ...
 
+
 class Image(Protocol):
+    """Type annotation for PIL's Image class"""
 
     @property
     def mode(self) -> str:

--- a/circuitpython_typing/pil.py
+++ b/circuitpython_typing/pil.py
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022 Alec Delaney
+#
+# SPDX-License-Identifier: MIT
+
+"""
+`circuitpython_typing.pil`
+================================================================================
+
+Type annotation definitions for PIL Images.
+
+* Author(s): Alec Delaney
+"""
+
+from typing import Tuple
+
+# Protocol was introduced in Python 3.8.
+try:
+    from typing import Protocol
+except ImportError:
+    from typing_extensions import Protocol
+
+class PixelAccess(Protocol):
+
+    def __getitem__(self, xy: Tuple[int, int]) -> int:
+        """Get pixels by x, y coordinate"""
+        ...
+
+class Image(Protocol):
+
+    @property
+    def mode(self) -> str:
+        """The mode of the image"""
+        ...
+
+    @property
+    def size(self) -> Tuple[int, int]:
+        """The size of the image"""
+        ...
+
+    def load(self) -> PixelAccess:
+        """Load the image for quick pixel access"""
+        ...


### PR DESCRIPTION
This would be helpful in `adafruit_framebuf` but I've also seen other libraries that use `PIL.Images` without requiring the package to be downloaded on installation.  This protocol allows for type annotations in this case.

Another fix would be to require `pip` to install `PIL` when the library is downloaded, but this allows that functionality to remain optional.