### PR TITLE
Add hardware value-property protocols

### DIFF
--- a/circuitpython_typing/io.py
+++ b/circuitpython_typing/io.py
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022 Alec Delaney
+#
+# SPDX-License-Identifier: MIT
+
+"""
+`circuitpython_typing.io`
+================================================================================
+
+Type annotation definitions for IO-related objects
+
+* Author(s): Alec Delaney
+"""
+
+# Protocol was introduced in Python 3.8.
+try:
+    from typing import Protocol
+except ImportError:
+    from typing_extensions import Protocol
+
+class ROValueIO(Protocol):
+    """Hardware objects, like `analogio.AnalogIn`, that have read-only
+    ``value`` properties/attributes.
+    """
+
+    @property
+    def value(self) -> float:
+        """Value property, that may return an `int` or `float` depending
+        on the specifics of the class.
+        """
+
+class ValueIO(Protocol):
+    """Hardware objects, like `analogio.AnalogOut`, that have read and
+    write ``value`` properties/attributes.
+    """
+
+    @property
+    def value(self) -> float:
+        """Value property, that may return an `int` or `float` depending
+        on the specifics of the class.
+        """
+
+    @value.setter
+    def value(self, input_value: float, /):
+        ...

--- a/circuitpython_typing/io.py
+++ b/circuitpython_typing/io.py
@@ -17,6 +17,7 @@ try:
 except ImportError:
     from typing_extensions import Protocol
 
+
 class ROValueIO(Protocol):
     """Hardware objects, like `analogio.AnalogIn`, that have read-only
     ``value`` properties/attributes.
@@ -27,6 +28,7 @@ class ROValueIO(Protocol):
         """Value property, that may return an `int` or `float` depending
         on the specifics of the class.
         """
+
 
 class ValueIO(Protocol):
     """Hardware objects, like `analogio.AnalogOut`, that have read and


### PR DESCRIPTION
Resolves #15 by adding Protocols for hardware classes with read-only and read/write `value` properties