### PR TITLE
Add HTTPProtocol

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,7 @@ jobs:
       run: |
         pip install --upgrade build twine
         for file in $(find -not -path "./.*" -not -path "./docs*" \( -name "*.py" -o -name "*.toml" \) ); do
-            sed -i -e "s/0.0.0-auto.0/1.2.3/" $file;
+            sed -i -e "s/0.0.0+auto.0/1.2.3/" $file;
         done;
         python -m build
         twine check dist/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,7 +82,7 @@ jobs:
         TWINE_PASSWORD: ${{ secrets.pypi_password }}
       run: |
         for file in $(find -not -path "./.*" -not -path "./docs*" \( -name "*.py" -o -name "*.toml" \) ); do
-            sed -i -e "s/0.0.0-auto.0/${{github.event.release.tag_name}}/" $file;
+            sed -i -e "s/0.0.0+auto.0/${{github.event.release.tag_name}}/" $file;
         done;
         python -m build
         twine upload dist/*

--- a/circuitpython_typing/__init__.py
+++ b/circuitpython_typing/__init__.py
@@ -11,7 +11,7 @@ Types needed for type annotation that are not in `typing`
 * Author(s): Alec Delaney, Dan Halbert, Randy Hudson
 """
 
-__version__ = "0.0.0-auto.0"
+__version__ = "0.0.0+auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_Typing.git"
 
 import array

--- a/circuitpython_typing/http.py
+++ b/circuitpython_typing/http.py
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022 Alec Delaney
+#
+# SPDX-License-Identifier: MIT
+
+"""
+`circuitpython_typing.http`
+===========================
+
+Type annotation definitions for HTTP and related objects
+
+* Author(s): Alec Delaney
+"""
+
+# Protocol was introduced in Python 3.8.
+from typing_extensions import Protocol
+from adafruit_requests import Response
+
+
+class HTTPProtocol(Protocol):
+    """Protocol for HTTP request managers, like typical wifi managers"""
+
+    def get(self, url: str, **kw) -> Response:
+        """Send HTTP GET request"""
+        ...
+
+    def put(self, url: str, **kw) -> Response:
+        """Send HTTP PUT request"""
+        ...
+
+    def post(self, url: str, **kw) -> Response:
+        """Send HTTP POST request"""
+        ...
+
+    def patch(self, url: str, **kw) -> Response:
+        """Send HTTP PATCH request"""
+        ...
+
+    def delete(self, url: str, **kw) -> Response:
+        """Send HTTP DELETE request"""
+        ...

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ requires = [
 [project]
 name = "adafruit-circuitpython-typing"
 description = "Types needed for type annotation that are not in `typing`"
-version = "0.0.0-auto.0"
+version = "0.0.0+auto.0"
 readme = "README.rst"
 authors = [
     {name = "Adafruit Industries", email = "circuitpython@adafruit.com"}

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@
 
 typing_extensions~=4.0
 adafruit-circuitpython-busdevice
+adafruit-circuitpython-requests


### PR DESCRIPTION
Spawned from discussion in https://github.com/adafruit/Adafruit_CircuitPython_LIFX/pull/15

This should make type annotations a little cleaner and that code (and likely elsewhere) by defining the behaviors needed in a HTTP requests class like the WiFi managers.

Also updates version strings so editable installs work, as was done for the other libraries.