### PR TITLE
Fix link to documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -57,7 +57,7 @@ To install in a virtual environment in your current project:
 
 Documentation
 =============
-API documentation for this library can be found on `Read the Docs <https://docs.circuitpython.org/projects/circuitpython_typing/en/latest/>`_.
+API documentation for this library can be found on `Read the Docs <https://docs.circuitpython.org/projects/adafruit-circuitpython-typing/en/latest/>`_.
 
 For information on building library documentation, please check out
 `this guide <https://learn.adafruit.com/creating-and-sharing-a-circuitpython-library/sharing-our-docs-on-readthedocs#sphinx-5-1>`_.


### PR DESCRIPTION
Hi,

Last time I worked on this repo, I noticed the link to the Docs was broken.

Thanks!

