### PR TITLE
pil additions

### DIFF
--- a/circuitpython_typing/pil.py
+++ b/circuitpython_typing/pil.py
@@ -11,7 +11,7 @@ Type annotation definitions for PIL Images.
 * Author(s): Alec Delaney
 """
 
-from typing import Tuple
+from typing import Tuple, Optional, Callable
 from typing_extensions import Protocol  # Safety import for Python 3.7
 
 
@@ -26,6 +26,7 @@ class PixelAccess(Protocol):
 class Image(Protocol):
     """Type annotation for PIL's Image class"""
 
+    # pylint: disable=too-many-arguments,invalid-name
     @property
     def mode(self) -> str:
         """The mode of the image"""
@@ -36,3 +37,27 @@ class Image(Protocol):
 
     def load(self) -> PixelAccess:
         """Load the image for quick pixel access"""
+
+    def convert(
+        self,
+        mode: str,
+        matrix: Optional[Tuple],
+        dither: Callable,
+        palette: int,
+        colors: int,
+    ):
+        """Returns a converted copy of this image."""
+
+    def rotate(
+        self,
+        angle: int,
+        resampling,
+        expand: int,
+        center: Tuple[int, int],
+        translate: Tuple[int, int],
+        fillcolor: int,
+    ):
+        """Returns a rotated copy of this image."""
+
+    def getpixel(self, xy: Tuple[int, int]):
+        """Returns the pixel value at a given position."""


### PR DESCRIPTION
resolves: #32 

These are needed for: [#111](https://github.com/adafruit/Adafruit_CircuitPython_RGB_Display/pull/111)

I was unsure of the type for `resampling`. From [Docs](https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.Image.rotate) it appears to take an enum from Resampling module. But unsure how we'd type that here.