### PR TITLE
Typing fixes

### DIFF
--- a/circuitpython_typing/__init__.py
+++ b/circuitpython_typing/__init__.py
@@ -15,8 +15,21 @@ __version__ = "0.0.0+auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_Typing.git"
 
 import array
-from typing import Union, Optional
-from typing_extensions import Protocol, TypeAlias  # Safety import for Python 3.7
+from typing import Optional, Union
+
+import alarm
+import audiocore
+import audiomixer
+import audiomp3
+import rgbmatrix
+import synthio
+import ulab
+from alarm.pin import PinAlarm
+from alarm.time import TimeAlarm
+
+# Protocol was introduced in Python 3.8, TypeAlias in 3.10
+from typing_extensions import Protocol, TypeAlias
+from ulab.numpy import ndarray
 
 # Lists below are alphabetized.
 

--- a/circuitpython_typing/__init__.py
+++ b/circuitpython_typing/__init__.py
@@ -20,6 +20,7 @@ from typing import TYPE_CHECKING, Optional, Union
 # Protocol was introduced in Python 3.8, TypeAlias in 3.10
 from typing_extensions import Protocol, TypeAlias
 
+# pylint: disable=used-before-assignment
 if TYPE_CHECKING:
     import alarm
     import audiocore
@@ -51,8 +52,8 @@ ReadableBuffer: TypeAlias = Union[
     bytearray,
     bytes,
     memoryview,
-    "rgbmatrix.RGBMatrix",
-    "ulab.numpy.ndarray",
+    rgbmatrix.RGBMatrix,
+    ulab.numpy.ndarray,
 ]
 """Classes that implement the readable buffer protocol."""
 
@@ -60,8 +61,8 @@ WriteableBuffer: TypeAlias = Union[
     array.array,
     bytearray,
     memoryview,
-    "rgbmatrix.RGBMatrix",
-    "ulab.numpy.ndarray",
+    rgbmatrix.RGBMatrix,
+    ulab.numpy.ndarray,
 ]
 """Classes that implement the writeable buffer protocol."""
 
@@ -143,20 +144,20 @@ class BlockDevice(Protocol):
 # These types may not be in adafruit-blinka, so use the string form instead of a resolved name.
 
 AudioSample: TypeAlias = Union[
-    "audiocore.WaveFile",
-    "audiocore.RawSample",
-    "audiomixer.Mixer",
-    "audiomp3.MP3Decoder",
-    "synthio.MidiTrack",
+    audiocore.WaveFile,
+    audiocore.RawSample,
+    audiomixer.Mixer,
+    audiomp3.MP3Decoder,
+    synthio.MidiTrack,
 ]
 """Classes that implement the audiosample protocol.
 You can play these back with `audioio.AudioOut`, `audiobusio.I2SOut` or `audiopwmio.PWMAudioOut`.
 """
 
-FrameBuffer: TypeAlias = Union["rgbmatrix.RGBMatrix"]
+FrameBuffer: TypeAlias = Union[rgbmatrix.RGBMatrix]
 """Classes that implement the framebuffer protocol."""
 
-Alarm: TypeAlias = Union["alarm.pin.PinAlarm", "alarm.time.TimeAlarm"]
+Alarm: TypeAlias = Union[alarm.pin.PinAlarm, alarm.time.TimeAlarm]
 """Classes that implement alarms for sleeping and asynchronous notification.
 You can use these alarms to wake up from light or deep sleep.
 """

--- a/circuitpython_typing/__init__.py
+++ b/circuitpython_typing/__init__.py
@@ -27,12 +27,12 @@ try:
     import ulab
     from alarm.pin import PinAlarm
     from alarm.time import TimeAlarm
+    from ulab.numpy import ndarray
 except ImportError:
     pass
 
 # Protocol was introduced in Python 3.8, TypeAlias in 3.10
 from typing_extensions import Protocol, TypeAlias
-from ulab.numpy import ndarray
 
 # Lists below are alphabetized.
 

--- a/circuitpython_typing/__init__.py
+++ b/circuitpython_typing/__init__.py
@@ -52,8 +52,8 @@ ReadableBuffer: TypeAlias = Union[
     bytearray,
     bytes,
     memoryview,
-    rgbmatrix.RGBMatrix,
-    ulab.numpy.ndarray,
+    "rgbmatrix.RGBMatrix",
+    "ulab.numpy.ndarray",
 ]
 """Classes that implement the readable buffer protocol."""
 
@@ -61,8 +61,8 @@ WriteableBuffer: TypeAlias = Union[
     array.array,
     bytearray,
     memoryview,
-    rgbmatrix.RGBMatrix,
-    ulab.numpy.ndarray,
+    "rgbmatrix.RGBMatrix",
+    "ulab.numpy.ndarray",
 ]
 """Classes that implement the writeable buffer protocol."""
 
@@ -144,20 +144,20 @@ class BlockDevice(Protocol):
 # These types may not be in adafruit-blinka, so use the string form instead of a resolved name.
 
 AudioSample: TypeAlias = Union[
-    audiocore.WaveFile,
-    audiocore.RawSample,
-    audiomixer.Mixer,
-    audiomp3.MP3Decoder,
-    synthio.MidiTrack,
+    "audiocore.WaveFile",
+    "audiocore.RawSample",
+    "audiomixer.Mixer",
+    "audiomp3.MP3Decoder",
+    "synthio.MidiTrack",
 ]
 """Classes that implement the audiosample protocol.
 You can play these back with `audioio.AudioOut`, `audiobusio.I2SOut` or `audiopwmio.PWMAudioOut`.
 """
 
-FrameBuffer: TypeAlias = Union[rgbmatrix.RGBMatrix]
+FrameBuffer: TypeAlias = Union["rgbmatrix.RGBMatrix"]
 """Classes that implement the framebuffer protocol."""
 
-Alarm: TypeAlias = Union[alarm.pin.PinAlarm, alarm.time.TimeAlarm]
+Alarm: TypeAlias = Union["alarm.pin.PinAlarm", "alarm.time.TimeAlarm"]
 """Classes that implement alarms for sleeping and asynchronous notification.
 You can use these alarms to wake up from light or deep sleep.
 """

--- a/circuitpython_typing/__init__.py
+++ b/circuitpython_typing/__init__.py
@@ -15,9 +15,12 @@ __version__ = "0.0.0+auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_Typing.git"
 
 import array
-from typing import Optional, Union
+from typing import TYPE_CHECKING, Optional, Union
 
-try:
+# Protocol was introduced in Python 3.8, TypeAlias in 3.10
+from typing_extensions import Protocol, TypeAlias
+
+if TYPE_CHECKING:
     import alarm
     import audiocore
     import audiomixer
@@ -28,11 +31,7 @@ try:
     from alarm.pin import PinAlarm
     from alarm.time import TimeAlarm
     from ulab.numpy import ndarray
-except ImportError:
-    pass
 
-# Protocol was introduced in Python 3.8, TypeAlias in 3.10
-from typing_extensions import Protocol, TypeAlias
 
 # Lists below are alphabetized.
 

--- a/circuitpython_typing/__init__.py
+++ b/circuitpython_typing/__init__.py
@@ -17,15 +17,18 @@ __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_Typing.git"
 import array
 from typing import Optional, Union
 
-import alarm
-import audiocore
-import audiomixer
-import audiomp3
-import rgbmatrix
-import synthio
-import ulab
-from alarm.pin import PinAlarm
-from alarm.time import TimeAlarm
+try:
+    import alarm
+    import audiocore
+    import audiomixer
+    import audiomp3
+    import rgbmatrix
+    import synthio
+    import ulab
+    from alarm.pin import PinAlarm
+    from alarm.time import TimeAlarm
+except ImportError:
+    pass
 
 # Protocol was introduced in Python 3.8, TypeAlias in 3.10
 from typing_extensions import Protocol, TypeAlias

--- a/circuitpython_typing/http.py
+++ b/circuitpython_typing/http.py
@@ -11,9 +11,10 @@ Type annotation definitions for HTTP and related objects
 * Author(s): Alec Delaney
 """
 
+from adafruit_requests import Response
+
 # Protocol was introduced in Python 3.8.
 from typing_extensions import Protocol
-from adafruit_requests import Response
 
 
 class HTTPProtocol(Protocol):

--- a/circuitpython_typing/io.py
+++ b/circuitpython_typing/io.py
@@ -38,7 +38,11 @@ class ValueIO(Protocol):
         on the specifics of the class.
         """
 
+    # TODO: this should be `value(self, input_value: float, /)` but can't
+    #   because currently mpy files are built and the `/` param isn't supported
+    #   in micro-python.
+    #   https://github.com/adafruit/Adafruit_CircuitPython_Typing/issues/36
     # pylint: disable=no-self-use,unused-argument
     @value.setter
-    def value(self, input_value: float, /):
+    def value(self, input_value: float):
         ...

--- a/circuitpython_typing/led.py
+++ b/circuitpython_typing/led.py
@@ -12,7 +12,8 @@ Type annotation definitions for LEDs.
 """
 
 # Protocol was introduced in Python 3.8, TypeAlias in 3.10
-from typing import Union, Tuple
+from typing import Tuple, Union
+
 from typing_extensions import Protocol, TypeAlias
 
 ColorBasedColorUnion: TypeAlias = Union[int, Tuple[int, int, int]]

--- a/circuitpython_typing/led.py
+++ b/circuitpython_typing/led.py
@@ -11,9 +11,9 @@ Type annotation definitions for LEDs.
 * Author(s): Alec Delaney
 """
 
-# Protocol was introduced in Python 3.8, TypeAlias in 3.10
 from typing import Tuple, Union
 
+# Protocol was introduced in Python 3.8, TypeAlias in 3.10
 from typing_extensions import Protocol, TypeAlias
 
 ColorBasedColorUnion: TypeAlias = Union[int, Tuple[int, int, int]]

--- a/circuitpython_typing/pil.py
+++ b/circuitpython_typing/pil.py
@@ -11,8 +11,10 @@ Type annotation definitions for PIL Images.
 * Author(s): Alec Delaney
 """
 
-from typing import Tuple, Optional, Callable
-from typing_extensions import Protocol  # Safety import for Python 3.7
+from typing import Callable, Optional, Tuple
+
+# Protocol was introduced in Python 3.8
+from typing_extensions import Protocol
 
 
 class PixelAccess(Protocol):

--- a/circuitpython_typing/socket.py
+++ b/circuitpython_typing/socket.py
@@ -13,9 +13,10 @@ from ssl import SSLContext
 from types import ModuleType
 from typing import Any, Optional, Tuple, Union
 
+from adafruit_connection_manager import _FakeSSLContext
+
 # Protocol was introduced in Python 3.8, TypeAlias in 3.10
 from typing_extensions import Protocol, TypeAlias
-
 
 # Based on https://github.com/python/typeshed/blob/master/stdlib/_socket.pyi
 
@@ -126,4 +127,4 @@ class InterfaceType(Protocol):
         """Constant representing that a socket's connection mode is TLS."""
 
 
-SSLContextType: TypeAlias = Union[SSLContext, "_FakeSSLContext"]
+SSLContextType: TypeAlias = Union[SSLContext, _FakeSSLContext]

--- a/circuitpython_typing/socket.py
+++ b/circuitpython_typing/socket.py
@@ -13,8 +13,6 @@ from ssl import SSLContext
 from types import ModuleType
 from typing import Any, Optional, Tuple, Union
 
-from adafruit_connection_manager import _FakeSSLContext
-
 # Protocol was introduced in Python 3.8, TypeAlias in 3.10
 from typing_extensions import Protocol, TypeAlias
 
@@ -125,6 +123,20 @@ class InterfaceType(Protocol):
     @property
     def TLS_MODE(self) -> int:  # pylint: disable=invalid-name
         """Constant representing that a socket's connection mode is TLS."""
+
+
+# pylint: disable=too-few-public-methods
+class _FakeSSLSocket:
+    """Describes the structure every fake SSL socket type must have."""
+
+
+class _FakeSSLContext:
+    """Describes the structure every fake SSL context type must have."""
+
+    def wrap_socket(
+        self, socket: CircuitPythonSocketType, server_hostname: Optional[str] = None
+    ) -> _FakeSSLSocket:
+        """Wrap socket and return a new one that uses the methods from the original."""
 
 
 SSLContextType: TypeAlias = Union[SSLContext, _FakeSSLContext]

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,5 @@
 
 Adafruit-Blinka
 adafruit-circuitpython-busdevice
-Adafruit-Circuitpython-connectionmanager@git+https://github.com/adafruit/Adafruit_CircuitPython_ConnectionManager@connection-manager
 adafruit-circuitpython-requests
 typing_extensions~=4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,6 @@
 
 Adafruit-Blinka
 adafruit-circuitpython-busdevice
+Adafruit-Circuitpython-connectionmanager@git+https://github.com/adafruit/Adafruit_CircuitPython_ConnectionManager@connection-manager
 adafruit-circuitpython-requests
 typing_extensions~=4.0


### PR DESCRIPTION
In this update:

1. Run `isort` to organize imports
2. When `TYPE_CHECKING` import types from `circuitpython-stubs`
3. define `_FakeSSLContext` in `socket.py` to simplify typing in other libraries