### PR TITLE
Require at least Python 3.8 due to `/` in function prototypes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ requires = [
 name = "adafruit-circuitpython-typing"
 description = "Types needed for type annotation that are not in `typing`"
 version = "0.0.0+auto.0"
+requires-python = ">=3.8"
 readme = "README.rst"
 authors = [
     {name = "Adafruit Industries", email = "circuitpython@adafruit.com"}


### PR DESCRIPTION
Once this is merged and 1.10.3 is released, I will delete the 1.10.2 release from here and pypi. Then 1.10.1 will be the last release compatible with python 3.7 and python 3.8 will be required going forward