### PR TITLE
fix markup indentation

### DIFF
--- a/circuitpython_typing/__init__.py
+++ b/circuitpython_typing/__init__.py
@@ -119,7 +119,7 @@ class BlockDevice(Protocol):
         * 3 - sync the device (``arg`` is unused)
         * 4 - get a count of the number of blocks, should return an integer (``arg`` is unused)
         * 5 - get the number of bytes in a block, should return an integer,
-            or ``None`` in which case the default value of 512 is used (``arg`` is unused)
+          or ``None`` in which case the default value of 512 is used (``arg`` is unused)
         * 6 - erase a block, arg is the block number to erase
 
         As a minimum ``ioctl(4, ...)`` must be intercepted; for littlefs ``ioctl(6, ...)``


### PR DESCRIPTION
Otherwise item 5 is styled in bold (not sure why!)  and the 2nd line is shown as a separate indented paragraph.

Before:
![image](https://github.com/user-attachments/assets/cd445b36-712e-4f12-84dd-de965ee97782)

After:
![image](https://github.com/user-attachments/assets/34092ece-626c-4ea6-9e90-e510229c3e55)
