### PR TITLE
Contribute ByteArray protocol

### DIFF
--- a/circuitpython_typing/byte_array.py
+++ b/circuitpython_typing/byte_array.py
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 Nate Gay
+# SPDX-License-Identifier: MIT
+"""
+`circuitpython_typing.byte_array`
+================================================================================
+
+Type annotation definitions for device drivers. Used for non-volatile memory access.
+
+* Author(s): Nate Gay
+"""
+
+
+from typing import overload, Union
+
+from typing_extensions import Protocol
+
+from . import ReadableBuffer
+
+
+class ByteArray(Protocol):
+    """Protocol for ByteArray used for NVM access."""
+
+    def __bool__(self) -> bool:
+        ...
+
+    def __len__(self) -> int:
+        """Return the length. This is used by (len)"""
+
+    @overload
+    def __getitem__(self, index: slice) -> bytearray:
+        ...
+
+    @overload
+    def __getitem__(self, index: int) -> int:
+        ...
+
+    def __getitem__(self, index: Union[slice, int]) -> Union[bytearray, int]:
+        """Returns the value at the given index."""
+
+    @overload
+    def __setitem__(self, index: slice, value: ReadableBuffer) -> None:
+        ...
+
+    @overload
+    def __setitem__(self, index: int, value: int) -> None:
+        ...
+
+    def __setitem__(
+        self, index: Union[slice, int], value: Union[ReadableBuffer, int]
+    ) -> None:
+        """Set the value at the given index."""


### PR DESCRIPTION
Hey CircuitPython typing team,

I found myself wanting type hinting for NVM access as described here: https://docs.circuitpython.org/en/latest/shared-bindings/nvm/index.html

I thought it might be useful for others so I'm attempting to contribute this back. Please let me know if this is the right place, if this addition is not desired or if you'd like me to make any changes. I do not need the copyright to be assigned to me so whatever you need, I'm happy to help.

Thanks!