### PR TITLE
use string instead of import for framebufferio

### DIFF
--- a/circuitpython_typing/displayio.py
+++ b/circuitpython_typing/displayio.py
@@ -15,6 +15,5 @@ from typing import TypeAlias, Union
 
 from busdisplay import BusDisplay
 from epaperdisplay import EPaperDisplay
-from framebufferio import FramebufferDisplay
 
-AnyDisplay: TypeAlias = Union[BusDisplay, EPaperDisplay, FramebufferDisplay]
+AnyDisplay: TypeAlias = Union[BusDisplay, EPaperDisplay, "framebufferio.FramebufferDisplay"]


### PR DESCRIPTION
`framebufferio` does not exist in Blinka_Displayio, so this was causing an import error when attempting to use it for a type annotation. 

I've updated the alias to use a string instead of the imported module for the type, in an environment were circuitpython-stubs is installed I think it might see the one from that in some IDEs still.

If framebufferio ever gets implemented in Blinka Displayio we could swap this back to importing.

This will resolve the actions failure from here: https://github.com/adafruit/Adafruit_CircuitPython_CursorControl/actions/runs/15351252647/job/43199774642?pr=41#step:2:1093

I tested the changed code successfully by building the docs for that PR branch locally with these changes. 