### PR TITLE
Fix BlockDevice Protocol

### DIFF
--- a/circuitpython_typing/__init__.py
+++ b/circuitpython_typing/__init__.py
@@ -93,49 +93,21 @@ class BlockDevice(Protocol):
     include `storage.VfsFat`.
     """
 
-    def readblocks(self, block_num: int, buf: bytearray) -> None:
+    def readblocks(self, start_block: int, buf: WriteableBuffer) -> None:
         """Read aligned, multiples of blocks. Starting at
-        the block given by the index ``block_num``, read blocks
-        from the device into ``buf`` (an array of bytes). The number
-        of blocks to read is given by the length of ``buf``,
-        which will be a multiple of the block size.
+        the block given by the index ``start_block``, read blocks
+        from the device into ``buf``. The number of blocks to
+        read is given by the length of ``buf``, which will be a
+        multiple of the block size.
         """
 
-    def writeblocks(self, block_num: int, buf: bytearray) -> None:
+    def writeblocks(self, start_block: int, buf: ReadableBuffer) -> None:
         """Write aligned, multiples of blocks, and require that
         the blocks that are written to be first erased (if necessary)
         by this method. Starting at the block given by the index
-        ``block_num``, write blocks from ``buf`` (an array of bytes) to the
-        device. The number of blocks to write is given by the length
+        ``start_block``, write blocks from ``buf`` to the device.
+        The number of blocks to write is given by the length
         of ``buf``, which will be a multiple of the block size.
-        """
-
-    def ioctl(self, operation: int, arg: Optional[int] = None) -> Optional[int]:
-        """Control the block device and query its parameters. The operation to
-        perform is given by ``operation`` which is one of the following integers:
-
-        * 1 - initialise the device (``arg`` is unused)
-        * 2 - shutdown the device (``arg`` is unused)
-        * 3 - sync the device (``arg`` is unused)
-        * 4 - get a count of the number of blocks, should return an integer (``arg`` is unused)
-        * 5 - get the number of bytes in a block, should return an integer,
-          or ``None`` in which case the default value of 512 is used (``arg`` is unused)
-        * 6 - erase a block, arg is the block number to erase
-
-        As a minimum ``ioctl(4, ...)`` must be intercepted; for littlefs ``ioctl(6, ...)``
-        must also be intercepted. The need for others is hardware dependent.
-
-        Prior to any call to ``writeblocks(block, ...)`` littlefs issues ``ioctl(6, block)``.
-        This enables a device driver to erase the block prior to a write if the hardware
-        requires it. Alternatively a driver might intercept ``ioctl(6, block)`` and return 0
-        (success). In this case the driver assumes responsibility for detecting the need
-        for erasure.
-
-        Unless otherwise stated ``ioctl(operation, arg)`` can return ``None``. Consequently an
-        implementation can ignore unused values of ``operation``. Where ``operation`` is
-        intercepted, the return value for operations 4 and 5 are as detailed above. Other
-        operations should return 0 on success and non-zero for failure, with the value returned
-        being an ``OSError`` errno code.
         """
 
 


### PR DESCRIPTION
Resolves #51

This PR modifies `BlockDevice` so that [`sdcardio.SDCard`](https://docs.circuitpython.org/en/latest/shared-bindings/sdcardio/index.html) adhears to the protocol.

This will prevent type errors from showing when providing an `sdcardio.SDCard` as an argument to [`storage.VfsFat`](https://docs.circuitpython.org/en/latest/shared-bindings/storage/index.html#storage.VfsFat).

<img width="1076" height="342" alt="Captura de pantalla 2025-08-31 a la(s) 10 58 59" src="https://github.com/user-attachments/assets/937b6734-6178-4159-adfd-08f16d2ff64f" />
